### PR TITLE
Add a minimum pip version to be used by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ sudo: true  # https://github.com/travis-ci/travis-ci/issues/9815
 branches:
   only:
   - master
+before_install: pip install --upgrade 'pip >= 18.1'
 install: pip install tox-travis
 script: tox
 deploy:


### PR DESCRIPTION
Pip 18.1 was the first to completely support PEP 517 and PEP 518 properly.
https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support