### PR TITLE
Replace Coveralls with --cov-fail-under

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ sudo: true  # https://github.com/travis-ci/travis-ci/issues/9815
 branches:
   only:
   - master
-install: pip install tox-travis coveralls
+install: pip install tox-travis
 script: tox
-after_success: coveralls
 deploy:
   provider: pypi
   user: dmtucker

--- a/README.rst
+++ b/README.rst
@@ -4,12 +4,10 @@ Backlog
 
 Track prioritized notes with this glorified TODO list.
 
-|Build Status| |Test Coverage| |PyPI Version|
+|Build Status| |PyPI Version|
 
 .. |Build Status| image:: https://img.shields.io/travis/dmtucker/backlog.svg
    :target: https://travis-ci.org/dmtucker/backlog
-.. |Test Coverage| image:: https://img.shields.io/coveralls/dmtucker/backlog.svg
-   :target: https://coveralls.io/github/dmtucker/backlog
 .. |PyPI Version| image:: https://img.shields.io/pypi/v/backlog.svg
    :target: https://pypi.org/project/backlog
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ deps =
 
     # https://github.com/pytest-dev
     pytest
-    pytest-cov
+    pytest-cov ~= 2.0
     pytest-randomly
 
     # other
@@ -33,5 +33,5 @@ commands =
     ./setup.py check --metadata --strict
     python -m backlog --version
     backlog --help
-    pytest --cov backlog --cov-report term-missing --flake8 --mypy-ignore-missing-imports --pylint {posargs}
+    pytest --cov backlog --cov-fail-under 100 --flake8 --mypy-ignore-missing-imports --pylint {posargs}
 """


### PR DESCRIPTION
Now that the project is at 100% code coverage and `tox` will fail if that drops, Coveralls is not necessary anymore.