### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
 - 3.7
 - 3.7-dev
+- 3.8-dev
 branches:
   only:
   - master
@@ -16,3 +17,4 @@ deploy:
     secure: n35Ze6Mj+lAQxTFVpdCN0wNz7HLddqKWHLzjZO6Z8a46Y1a3PYMNX7XRA+Qb+P1zz38a27N+oQ8IlyRVXBFya/Z5VRbb2gX1evClNAan1lljyT8d7vu7VYTzeuX/ewM8VMt60HEGvpWvF88OpUycTJ1OxY9wMWtL44O8bUxWr2dmrZFLXlYQ6MfLnDDUdp5+UMD5462dPG91TkOFRDVW8VASieJ0pV1nlCvdTgo5UVH8mP4AckNgfuu6P7wWQAJBeo6La1uxqg0nj1OFsyhBMGNg+tHPJqPoZtIFFFCw21nczFuv0DIGM3miyf8ErkAC6RuvpJVdm1Xt1FfwT5Rglshun5CAVMRPLVbU9gduCut2HvUmNPo98m/OMmiAHp1P6NVIYor6Ls4i521eGxigczSslGNHwyjoXHA1AJeIvGymX4QtrehCqHl0rwZZX+4UkX9Yp3kyPT4ELswzKd8YyMHWvHvgmnxj5ZG+ex30qwhQT0KgE5R1QKYNhgrJaFG+vSIsH1wH2Q7UduBpwqtBlRYQaN+P5ZGPB4vUPwTCDJN8tKdgyqNL0E2UnUu7+ac80lGo2+BMYXA0VrkKPmhUC1TYKZCudRJVg1Mp638m+xu7g941zLjFBEzuIWGF17RXi7+PjeGlpUuCbekUrxuJ/851IZQY1bjzvUE6CUgUv3Y=
   on:
     tags: true
+    python: '3.7'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ legacy_tox_ini = """
 
 envlist =
     py37
+    py38
 
 [testenv]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ deps =
     pytest-pylint
 
 commands =
-    ./setup.py check --metadata --strict
+    python setup.py check --metadata --strict
     python -m backlog --version
     backlog --help
     pytest --cov backlog --cov-fail-under 100 --flake8 --mypy-ignore-missing-imports --pylint {posargs}

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3.7
-
 """A setuptools based setup module.
 
 See:

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setuptools.setup(
     ],
     extras_require={
         'dev': [
-            'tox',
+            'tox >= 3.1.3, < 4',
             'twine',
         ],
     },
@@ -62,8 +62,8 @@ setuptools.setup(
         'License :: OSI Approved :: '
         'GNU Lesser General Public License v2 or later (LGPLv2+)',
         'Intended Audience :: End Users/Desktop',
-        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Development Status :: 5 - Production/Stable',
     ],
 )

--- a/src/backlog/cli.py
+++ b/src/backlog/cli.py
@@ -61,7 +61,8 @@ def add(ctx, title: str, note: str, priority: int) -> None:
 @click.pass_context
 def random(ctx) -> None:
     """Select a random entry from the backlog."""
-    entry = ctx.obj['backlog'].random()
+    # https://github.com/PyCQA/pylint/issues/2737
+    entry = ctx.obj['backlog'].random()  # pylint: disable=multiple-statements
     if entry:
         click.echo(str(entry))
 


### PR DESCRIPTION
Tox is pinned to allow new minor versions because nothing additional/unspecified is in use that should affect the `tox` interface (e.g. custom CLI options, custom directives in `tox.ini`, etc.). The risk with automatically allowing new minor versions is that a feature will be added that collides with something that already exists.