### PR TITLE
Add tox -e publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,26 +1,17 @@
-name: Publish to PyPI
-
+name: Publish
 on:
   release:
     types: [created]
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
+    - uses: actions/setup-python@v1
       with:
-        python-version: '3.7'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade pep517 twine
-    - name: Build and publish
-      env:
+        python-version: '3.8'
+    - run: python -m pip install --upgrade tox-gh-actions
+    - env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python -m pep517.build .
-        twine upload dist/*
+      run: tox -e publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,8 @@ jobs:
         python-version: [3.7, 3.8]
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+    - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade tox tox-gh-actions
-    - name: Test with tox
-      run: tox
+    - run: python -m pip install --upgrade tox-gh-actions
+    - run: tox

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ if __name__ == '__main__':
         use_scm_version=True,
         description='A Glorified TODO list',
         long_description=read('README.rst'),
+        long_description_content_type='text/x-rst',
         author='David Tucker',
         author_email='david@tucker.name',
         license='LGPLv2+',

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,11 @@ envlist =
     static
     docs
 
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38, static, docs
+
 [testenv]
 deps =
     pytest ~= 5.2.0
@@ -41,7 +46,11 @@ commands =
     mypy --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs --disallow-untyped-decorators src
     pylint src
 
-[gh-actions]
-python =
-    3.7: py37
-    3.8: py38, static, docs
+[testenv:publish]
+passenv = TWINE_*
+deps =
+    pep517
+    twine
+commands =
+    python -m pep517.build --out-dir {distdir} .
+    twine upload {distdir}/*


### PR DESCRIPTION
This enables the publishing of untagged builds.
It also adds `long_description_content_type` to `setup.py` to resolve this `twine check` warning:
```
Checking dist/backlog-2.0.3.dev4+g4dd2afe.d20200222.tar.gz: PASSED, with warnings
  warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
```