### PR TITLE
Handle bad patterns gracefully

### DIFF
--- a/src/backlog/api.py
+++ b/src/backlog/api.py
@@ -6,8 +6,7 @@ import dataclasses
 import json
 import os
 import random
-import re
-from typing import Any, Generator, List, Optional
+from typing import Any, Generator, List, Optional, Pattern
 
 
 @dataclasses.dataclass
@@ -95,10 +94,10 @@ class Backlog:
     # https://github.com/PyCQA/pyflakes/issues/427
     def search(
             self,
-            pattern: str,
+            pattern: Pattern[str],
             invert: bool = False,
     ) -> Generator[Entry, None, None]:  # noqa: F821
         """Find Entries in the Backlog."""
         for entry in self.entries:
-            if (re.search(pattern, entry.title) is None) == invert:
+            if (pattern.search(entry.title) is None) == invert:
                 yield entry

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,7 @@
 # https://github.com/PyCQA/pylint/issues/2261
 import dataclasses  # pylint: disable=wrong-import-order
 import os
+import re
 import uuid
 
 import pytest
@@ -83,26 +84,26 @@ def test_backlog_save_empty(path):
 def test_backlog_search(backlog_entry):
     """Searching a Backlog must match Entry objects by title."""
     backlog, entry = backlog_entry
-    assert list(backlog.search(pattern=entry.title)) == [entry]
+    assert list(backlog.search(pattern=re.compile(entry.title))) == [entry]
 
 
 @pytest.mark.parametrize('invert', [True, False])
 def test_backlog_search_empty(invert):
     """Searching an empty Backlog must not return any Entries."""
     with pytest.raises(StopIteration):
-        next(api.Backlog().search(pattern='.*', invert=invert))
+        next(api.Backlog().search(pattern=re.compile('.*'), invert=invert))
 
 
 def test_backlog_search_invert(backlog):
     """Doing an inverted search should not return matches."""
     with pytest.raises(StopIteration):
-        next(backlog.search(pattern='.*', invert=True))
+        next(backlog.search(pattern=re.compile('.*'), invert=True))
 
 
 def test_backlog_search_unmatchable(backlog):
     """Searching for nonexistent Entries should not return matches."""
     with pytest.raises(StopIteration):
-        next(backlog.search(pattern=str(uuid.uuid4())))
+        next(backlog.search(pattern=re.compile(str(uuid.uuid4()))))
 
 
 def test_entry_eq_bad_type(entry):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,6 +68,14 @@ def test_remove(saved_backlog):
         assert excinfo.value.code != 0
 
 
+@pytest.mark.parametrize('flag', ['--ask', '--dont-ask'])
+def test_remove_bad_pattern(path, flag):
+    """Test an invocation of remove with an invalid pattern."""
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(['--path', path, 'remove', flag, '*'])
+    assert excinfo.value.code != 0
+
+
 def test_remove_ask(saved_backlog):
     """Test an invocation of remove."""
     _, path = saved_backlog


### PR DESCRIPTION
Fix #10 

```
$ backlog remove '*'
Usage: backlog remove [OPTIONS] PATTERN
Try 'backlog remove --help' for help.

Error: Invalid value for 'PATTERN': nothing to repeat at position 0
```