### PR TITLE
Set testpaths in [pytest] in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,9 @@ python =
     3.8: py38, static, docs, publish
     3.9: py39
 
+[pytest]
+testpaths = tests
+
 [testenv]
 deps =
     pytest ~= 6.1.0
@@ -22,7 +25,7 @@ deps =
     pytest-randomly ~= 3.4.0
     pytest-xdist ~= 2.1.0
 commands =
-    pytest --cov backlog --cov-fail-under 100 --cov-report term-missing {posargs:-n auto} tests
+    pytest --cov backlog --cov-fail-under 100 --cov-report term-missing {posargs:-n auto}
 
 [testenv:docs]
 basepython = python3.8


### PR DESCRIPTION
This enables running tests by node ID via tox `{posargs}`.
#### Before
```
$ tox -e py39
...
Required test coverage of 100% reached. Total coverage: 100.00%
================================================= 43 passed in 1.33s =================================================
______________________________________________________ summary _______________________________________________________
  py39: commands succeeded
  congratulations :)
```
- `tests` :+1: 
```
$ tox -e py39 -- 'tests/test_api.py::test_backlog_search_empty[True]'
...
Required test coverage of 100% reached. Total coverage: 100.00%

================================================= 44 passed in 0.40s =================================================
______________________________________________________ summary _______________________________________________________
  py39: commands succeeded
  congratulations :)
```
- `tests` :-1:
- `tests/test_api.py::test_backlog_search_empty[True]` (again) :+1: 

#### After
```
$ tox -e py39
...
Required test coverage of 100% reached. Total coverage: 100.00%
================================================= 43 passed in 1.35s =================================================
______________________________________________________ summary _______________________________________________________
  py39: commands succeeded
  congratulations :)
```
- `tests` :+1: 
```
$ tox -e py39 -- 'tests/test_api.py::test_backlog_search_empty[True]'
...
FAIL Required test coverage of 100% not reached. Total coverage: 28.43%

================================================= 1 passed in 0.05s ==================================================
ERROR: InvocationError for command /home/dtux/Projects/backlog/.tox/py39/bin/pytest --cov backlog --cov-fail-under 100 --cov-report term-missing 'tests/test_api.py::test_backlog_search_empty[True]' (exited with code 1)
______________________________________________________ summary _______________________________________________________
ERROR:   py39: commands failed
```
- `tests/test_api.py::test_backlog_search_empty[True]` (only) :+1: 